### PR TITLE
Fix hero subtitle flicker before typewriter animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -101,15 +101,20 @@ function typewriterEffect(element, text, speed = 50) {
 document.addEventListener('DOMContentLoaded', function() {
     // Create terminal cursor
     createTerminalCursor();
-    
-    // Typewriter effect for subtitle (delayed)
-    setTimeout(() => {
-        const subtitle = document.querySelector('.hero-subtitle');
-        if (subtitle) {
-            const originalText = subtitle.textContent;
+
+    // Prepare hero subtitle text so it doesn't flash before the typewriter starts
+    const subtitle = document.querySelector('.hero-subtitle');
+    if (subtitle) {
+        const originalText = subtitle.textContent.trim();
+        subtitle.setAttribute('data-original-text', originalText);
+        subtitle.setAttribute('aria-label', originalText);
+        subtitle.textContent = '';
+
+        // Typewriter effect for subtitle (delayed)
+        setTimeout(() => {
             typewriterEffect(subtitle, originalText, 30);
-        }
-    }, 2000);
+        }, 2000);
+    }
 });
 
 // Dynamic terminal lines


### PR DESCRIPTION
## Summary
- prevent the hero subtitle text from flashing before the typewriter animation by clearing it on load and storing the original content
- retain accessibility context via an aria-label while reusing the stored text for the delayed typewriter effect

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d156a1923c833191267189a91cca7b