### PR TITLE
Align hero subtitle cursor with typewriter text

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,67 +49,56 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
-// Terminal cursor effect for hero title
-function createTerminalCursor() {
-    const heroTitle = document.querySelector('.hero-title');
-    if (heroTitle) {
-        const originalText = heroTitle.innerHTML;
-        heroTitle.innerHTML = originalText + '<span class="terminal-cursor">|</span>';
-        
-        // Add CSS for cursor animation
-        const style = document.createElement('style');
-        style.textContent = `
-            .terminal-cursor {
-                animation: blink 1s infinite;
-                color: #00FFCC;
-            }
-            
-            @keyframes blink {
-                0%, 50% { opacity: 1; }
-                51%, 100% { opacity: 0; }
-            }
-        `;
-        document.head.appendChild(style);
-        
-        // Remove cursor after animation
-        setTimeout(() => {
-            const cursor = document.querySelector('.terminal-cursor');
-            if (cursor) {
-                cursor.remove();
-            }
-        }, 5000);
-    }
-}
-
 // Typewriter effect for hero subtitle
-function typewriterEffect(element, text, speed = 50) {
-    element.innerHTML = '';
+function typewriterEffect(element, text, speed = 50, onComplete) {
+    element.textContent = '';
     let i = 0;
-    
+
     function typeChar() {
         if (i < text.length) {
-            element.innerHTML += text.charAt(i);
+            element.textContent += text.charAt(i);
             i++;
             setTimeout(typeChar, speed);
+        } else if (typeof onComplete === 'function') {
+            onComplete();
         }
     }
-    
+
     typeChar();
 }
 
 // Initialize animations when page loads
 document.addEventListener('DOMContentLoaded', function() {
-    // Create terminal cursor
-    createTerminalCursor();
-    
-    // Typewriter effect for subtitle (delayed)
-    setTimeout(() => {
-        const subtitle = document.querySelector('.hero-subtitle');
-        if (subtitle) {
-            const originalText = subtitle.textContent;
-            typewriterEffect(subtitle, originalText, 30);
-        }
-    }, 2000);
+    // Prepare hero subtitle text so it doesn't flash before the typewriter starts
+    const subtitle = document.querySelector('.hero-subtitle');
+    if (subtitle) {
+        const originalText = subtitle.textContent.trim();
+        subtitle.setAttribute('data-original-text', originalText);
+        subtitle.setAttribute('aria-label', originalText);
+        subtitle.textContent = '';
+
+        const wrapper = document.createElement('span');
+        wrapper.className = 'typewriter-wrapper';
+
+        const textSpan = document.createElement('span');
+        textSpan.className = 'typewriter-text';
+
+        const cursorSpan = document.createElement('span');
+        cursorSpan.className = 'typewriter-cursor';
+        cursorSpan.setAttribute('aria-hidden', 'true');
+        cursorSpan.textContent = '|';
+
+        wrapper.appendChild(textSpan);
+        wrapper.appendChild(cursorSpan);
+        subtitle.appendChild(wrapper);
+
+        // Typewriter effect for subtitle (delayed)
+        setTimeout(() => {
+            typewriterEffect(textSpan, originalText, 30, () => {
+                subtitle.classList.add('typewriter-complete');
+            });
+        }, 2000);
+    }
 });
 
 // Dynamic terminal lines

--- a/styles.css
+++ b/styles.css
@@ -194,6 +194,41 @@ body {
     margin-right: auto;
 }
 
+.hero-subtitle .typewriter-wrapper {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.15ch;
+}
+
+.hero-subtitle .typewriter-text {
+    display: inline;
+    white-space: pre;
+}
+
+.hero-subtitle .typewriter-cursor {
+    display: inline-block;
+    width: 0.6ch;
+    color: #00FFCC;
+    animation: typewriter-blink 1s steps(1, end) infinite;
+    line-height: 1;
+    font-size: 1em;
+}
+
+.hero-subtitle.typewriter-complete .typewriter-cursor {
+    animation: none;
+    opacity: 0;
+}
+
+@keyframes typewriter-blink {
+    0%, 50% {
+        opacity: 1;
+    }
+
+    51%, 100% {
+        opacity: 0;
+    }
+}
+
 .hero-buttons {
     display: flex;
     gap: 1.5rem;


### PR DESCRIPTION
## Summary
- prevent the hero subtitle text from flashing before the typewriter animation by clearing it on load and storing the original content
- retain accessibility context via an aria-label while reusing the stored text for the delayed typewriter effect
- keep the typewriter cursor inline with the subtitle copy by rendering dedicated text/cursor spans and styling the cursor to blink beside the typed characters

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d156a1923c833191267189a91cca7b